### PR TITLE
Refactor onboarding navigation bar and onInit method in onboarding co…

### DIFF
--- a/lib/features/onboarding/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/controller/onboarding_controller.dart
@@ -45,8 +45,12 @@ class OnboardingController extends GetxController {
           image: AppAssets.imagesWarranty,
           title: AppStrings.warranty),
     ];
-    setIsOnBoardingVisited();
     super.onInit();
+  }
+  @override
+  void onReady() {
+    super.onReady();
+    setIsOnBoardingVisited();
   }
 
   void setIsOnBoardingVisited() {

--- a/lib/features/onboarding/view/widgets/onboarding_navigation_bar.dart
+++ b/lib/features/onboarding/view/widgets/onboarding_navigation_bar.dart
@@ -16,24 +16,26 @@ class OnboardingNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        const TextWidget(
-          text: AppStrings.skip,
-          onTap: navigateToLoginView,
-        ),
-        const Spacer(),
-        GetBuilder<OnboardingController>(
-            builder: (controller) => controller.isLastOnboardingPage()
-                ? const TextWidget(
-                    text: AppStrings.startNow,
-                    onTap: navigateToLoginView,
-                  )
-                : TextWidget(
-                    text: AppStrings.next,
-                    onTap: onboardingController.nextPage,
-                  ))
-      ],
-    );
+    return GetBuilder<OnboardingController>(
+        builder: (controller) => Row(
+              children: [
+                controller.isLastOnboardingPage()
+                    ? const SizedBox.shrink()
+                    : const TextWidget(
+                        text: AppStrings.skip,
+                        onTap: navigateToLoginView,
+                      ),
+                const Spacer(),
+                controller.isLastOnboardingPage()
+                    ? const TextWidget(
+                        text: AppStrings.startNow,
+                        onTap: navigateToLoginView,
+                      )
+                    : TextWidget(
+                        text: AppStrings.next,
+                        onTap: onboardingController.nextPage,
+                      )
+              ],
+            ));
   }
 }


### PR DESCRIPTION
…ntroller

- Refactored the onboarding navigation bar widget to use GetBuilder instead of const widgets for better state management.
- Moved the setIsOnBoardingVisited method call from onInit to onReady in the onboarding controller to ensure that the cache is initialized before setting the value.